### PR TITLE
build: Spring Bootを3.5.5にアップグレード

### DIFF
--- a/BookOfAdventureClient/src/main/resources/META-INF/spring.factories
+++ b/BookOfAdventureClient/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-net.hero.rogueb.bookofadventureclient.BookOfAdventureServiceClientConfiguration

--- a/BookOfAdventureClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/BookOfAdventureClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.hero.rogueb.bookofadventureclient.BookOfAdventureServiceClientConfiguration

--- a/DungeonClient/src/main/resources/META-INF/spring.factories
+++ b/DungeonClient/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-net.hero.rogueb.dungeonclient.DungeonServiceConfiguration

--- a/DungeonClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/DungeonClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.hero.rogueb.dungeonclient.DungeonServiceConfiguration

--- a/ObjectsClient/src/main/resources/META-INF/spring.factories
+++ b/ObjectsClient/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-net.hero.rogueb.objectclient.ObjectServiceConfiguration

--- a/ObjectsClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/ObjectsClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.hero.rogueb.objectclient.ObjectServiceConfiguration

--- a/WorldClient/src/main/resources/META-INF/spring.factories
+++ b/WorldClient/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-net.hero.rogueb.worldclient.WorldServiceConfiguration

--- a/WorldClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/WorldClient/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.hero.rogueb.worldclient.WorldServiceConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.1</version>
+        <version>3.5.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>net.hero.rogueb</groupId>
@@ -39,16 +39,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgs>--enable-preview</compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--enable-preview</argLine>
-                </configuration>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
Spring Bootのバージョンを2.6.1から3.5.5に更新しました。これにより、Spring Frameworkのバージョンも6.x系にアップグレードされます。

アップグレードに伴い、maven-compiler-pluginがJava 17でのプレビュー機能（--enable-preview）をサポートしなくなったため、ビルドエラーが発生しました。プロジェクト内ではプレビュー機能は使用されていなかったため、pom.xmlから--enable-previewフラグを削除して対応しました。

修正後、すべてのモジュールでビルドが成功し、テストがパスすることを確認済みです。