### PR TITLE
[追加] モンスター融合関連種族のドメイン定義追加

### DIFF
--- a/docs/features/domain_models/Monster.md
+++ b/docs/features/domain_models/Monster.md
@@ -204,6 +204,10 @@
 | `demon` | [デーモン](#species-demon) | `DEMON` | 3 | Dark | 300 | 150 | 120 | 50 | 35 | 25 | 30 | 30 | 12 | 15 | `V` | - | 201 | NORMAL | 35 | 1500 | 5000 | - |
 | `mist_spirit` | [ミストスピリット](#species-mist_spirit) | `SPIRIT` | 3 | Water | 350 | 180 | 70 | 80 | 15 | 15 | 35 | 30 | 25 | 20 | `M` | - | 202, 302, 304 | NORMAL | 40 | 1200 | 3000 | - |
 | `ancient_dragon` | [古代龍](#species-ancient_dragon) | `DRAGON` | 5 | Fire | 2500 | 1000 | 300 | 100 | 80 | 60 | 50 | 40 | 25 | 20 | `A` | `FIRE_IMMUNITY`, `STATUS_IMMUNITY`, `MIASMA_RESISTANCE` | 201, 401, 403 | NORMAL | 50 | 1500 | 10000 | - |
+| `metal_spirit` | [メタルスピリット](#species-metal_spirit) | `SPIRIT` | 2 | None | 120 | 60 | 30 | 40 | 8 | 40 | 15 | 35 | 15 | 25 | `m` | `MIASMA_RESISTANCE` | 103 | NORMAL | 30 | 1000 | 2000 | - |
+| `metal_slime` | [メタルスライム](#species-metal_slime) | `SLIME` | 2 | None | 180 | 300 | 8 | 20 | 15 | 200 | 5 | 150 | 40 | 50 | `x` | `SLIME_BODY`, `STATUS_IMMUNITY` | 105 | COWARDLY | 25 | 800 | 3000 | - |
+| `high_demon` | [ハイデーモン](#species-high_demon) | `DEMON` | 4 | Dark | 600 | 350 | 160 | 80 | 45 | 32 | 40 | 35 | 15 | 20 | `E` | `AGGRESSIVE` | 204 | AGGRESSIVE | 40 | 1200 | 5000 | - |
+| `gale_wolf` | [ゲイルウルフ](#species-gale_wolf) | `BEAST` | 3 | Wind | 250 | 110 | 60 | 20 | 25 | 18 | 12 | 15 | 30 | 12 | `K` | `TRACKING` | 105 | AGGRESSIVE | 30 | 900 | 2500 | - |
 | `town_guardian` | [拠点衛兵](#species-town_guardian) | `HUMANOID` | - | None | - | 0 | 500 | 200 | 100 | 100 | 80 | 80 | 50 | 50 | `g` | `STATUS_IMMUNITY`, `SEE_INVISIBILITY` | 303 | STATIONARY | 100 | 800 | - | - |
 | `bounty_hunter` | [賞金稼ぎ](#species-bounty_hunter) | `HUMANOID` | 4 | None | - | 0 | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | `H` | `TRACKING`, `SEE_INVISIBILITY` | - | AGGRESSIVE | 40 | 1000 | - | [詳細](../Monster-PK-System.md#742-賞金稼ぎ-npc-bounty-hunter) |
 
@@ -234,6 +238,10 @@
 | <a id="species-griffin"></a>`griffin` | `401`: ウィンドブレス (1), `102`: 回転斬り (20) |
 | <a id="species-mist_spirit"></a>`mist_spirit` | `202`: アイスブレス (1), `302`: ポイズンガス (1), `304`: スリープクラウド (1), `602`: 分裂 (40) |
 | <a id="species-ancient_dragon"></a>`ancient_dragon` | `201`: ファイアボール (1), `401`: ウィンドブレス (1), `403`: トルネード (1), `308`: ヘイスト (50) |
+| <a id="species-metal_spirit"></a>`metal_spirit` | `103`: シールドバッシュ (1), `203`: アースニードル (15), `106`: 大粉砕 (30) |
+| <a id="species-metal_slime"></a>`metal_slime` | `105`: かみつき (1), `501`: テレポート (10), `101`: パワーアタック (20), `602`: 分裂 (35) |
+| <a id="species-high_demon"></a>`high_demon` | `201`: ファイアボール (1), `204`: ダークブレス (1), `102`: 回転斬り (10), `305`: コンフューズ (15), `501`: テレポート (30), `404`: クエイク (45) |
+| <a id="species-gale_wolf"></a>`gale_wolf` | `105`: かみつき (1), `401`: ウィンドブレス (10), `310`: 遠吠え (20), `403`: トルネード (35) |
 | <a id="species-town_guardian"></a>`town_guardian` | `303`: 捕縛 (1) |
 | <a id="species-bounty_hunter"></a>`bounty_hunter` | `101`: パワーアタック (1), `303`: 捕縛 (1) |
 


### PR DESCRIPTION
モンスター融合仕様書（Monster-Fusion-System.md）に定義されているが、モンスタードメイン定義（Monster.md）に詳細が定義されていなかった4つの融合関連種族（metal_spirit, metal_slime, high_demon, gale_wolf）について、基本パラメータと習得スキルテーブルを追記しました。これにより実装不整合が解消されます。

---
*PR created automatically by Jules for task [8230006836295116699](https://jules.google.com/task/8230006836295116699) started by @yamanakahirofumi*