### PR TITLE
[追加] モンスター種族定義に融合関連種族（メタルスピリット、メタルスライム、ハイデーモン、ゲイルウルフ）を追加

### DIFF
--- a/docs/features/domain_models/Monster.md
+++ b/docs/features/domain_models/Monster.md
@@ -204,6 +204,10 @@
 | `demon` | [デーモン](#species-demon) | `DEMON` | 3 | Dark | 300 | 150 | 120 | 50 | 35 | 25 | 30 | 30 | 12 | 15 | `V` | - | 201 | NORMAL | 35 | 1500 | 5000 | - |
 | `mist_spirit` | [ミストスピリット](#species-mist_spirit) | `SPIRIT` | 3 | Water | 350 | 180 | 70 | 80 | 15 | 15 | 35 | 30 | 25 | 20 | `M` | - | 202, 302, 304 | NORMAL | 40 | 1200 | 3000 | - |
 | `ancient_dragon` | [古代龍](#species-ancient_dragon) | `DRAGON` | 5 | Fire | 2500 | 1000 | 300 | 100 | 80 | 60 | 50 | 40 | 25 | 20 | `A` | `FIRE_IMMUNITY`, `STATUS_IMMUNITY`, `MIASMA_RESISTANCE` | 201, 401, 403 | NORMAL | 50 | 1500 | 10000 | - |
+| `metal_spirit` | [メタルスピリット](#species-metal_spirit) | `SPIRIT` | 2 | Earth | 120 | 60 | 40 | 40 | 10 | 15 | 20 | 20 | 15 | 15 | `m` | - | 103 | NORMAL | 30 | 1000 | 2000 | - |
+| `metal_slime` | [メタルスライム](#species-metal_slime) | `SLIME` | 2 | None | 150 | 80 | 15 | 10 | 12 | 60 | 5 | 40 | 25 | 20 | `x` | `SLIME_BODY`, `STATUS_IMMUNITY` | 306 | NORMAL | 25 | 1000 | 2500 | - |
+| `high_demon` | [ハイデーモン](#species-high_demon) | `DEMON` | 4 | Dark | 600 | 300 | 160 | 80 | 45 | 30 | 40 | 35 | 15 | 20 | `Y` | - | 201, 204 | AGGRESSIVE | 40 | 1500 | 5000 | - |
+| `gale_wolf` | [ゲイルウルフ](#species-gale_wolf) | `BEAST` | 3 | Wind | 300 | 150 | 75 | 40 | 28 | 20 | 20 | 15 | 25 | 15 | `F` | `TRACKING` | 105 | AGGRESSIVE | 30 | 1000 | 3000 | - |
 | `town_guardian` | [拠点衛兵](#species-town_guardian) | `HUMANOID` | - | None | - | 0 | 500 | 200 | 100 | 100 | 80 | 80 | 50 | 50 | `g` | `STATUS_IMMUNITY`, `SEE_INVISIBILITY` | 303 | STATIONARY | 100 | 800 | - | - |
 | `bounty_hunter` | [賞金稼ぎ](#species-bounty_hunter) | `HUMANOID` | 4 | None | - | 0 | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | (Scaling) | `H` | `TRACKING`, `SEE_INVISIBILITY` | - | AGGRESSIVE | 40 | 1000 | - | [詳細](../Monster-PK-System.md#742-賞金稼ぎ-npc-bounty-hunter) |
 
@@ -234,6 +238,10 @@
 | <a id="species-griffin"></a>`griffin` | `401`: ウィンドブレス (1), `102`: 回転斬り (20) |
 | <a id="species-mist_spirit"></a>`mist_spirit` | `202`: アイスブレス (1), `302`: ポイズンガス (1), `304`: スリープクラウド (1), `602`: 分裂 (40) |
 | <a id="species-ancient_dragon"></a>`ancient_dragon` | `201`: ファイアボール (1), `401`: ウィンドブレス (1), `403`: トルネード (1), `308`: ヘイスト (50) |
+| <a id="species-metal_spirit"></a>`metal_spirit` | `103`: シールドバッシュ (1), `306`: マヒの粉 (15) |
+| <a id="species-metal_slime"></a>`metal_slime` | `306`: マヒの粉 (1), `103`: シールドバッシュ (10), `602`: 分裂 (25) |
+| <a id="species-high_demon"></a>`high_demon` | `201`: ファイアボール (1), `204`: ダークブレス (1), `102`: 回転斬り (15), `501`: テレポート (20), `403`: トルネード (40) |
+| <a id="species-gale_wolf"></a>`gale_wolf` | `105`: かみつき (1), `401`: ウィンドブレス (10), `310`: 遠吠え (20), `403`: トルネード (35) |
 | <a id="species-town_guardian"></a>`town_guardian` | `303`: 捕縛 (1) |
 | <a id="species-bounty_hunter"></a>`bounty_hunter` | `101`: パワーアタック (1), `303`: 捕縛 (1) |
 


### PR DESCRIPTION
Monster.mdにおける初期実装モンスターデータテーブル（セクション 5.1）および各種族の習得スキルテーブル（セクション 5.2）に、融合関連の4種族（metal_spirit、metal_slime、high_demon、gale_wolf）の仕様定義を追加しました。これにより、特殊進化合体テーブルとの一貫性を確実に保証します。

---
*PR created automatically by Jules for task [15578230492364594541](https://jules.google.com/task/15578230492364594541) started by @yamanakahirofumi*