### PR TITLE
[追加] アイテムエンチャントシステムのAPI仕様およびエラーハンドリングの追加

### DIFF
--- a/docs/TODO-Details.md
+++ b/docs/TODO-Details.md
@@ -41,6 +41,10 @@ AIによる生成が困難な、感性やバランス調整が必要な事項で
 ## 6. 完了済み事項
 これまでに検討が完了し、仕様が策定された事項です。
 
+### [x] アイテムエンチャントシステムのAPI仕様およびエラーハンドリングの追加
+- **概要**: 確実に実装するのに不足していた、アイテムエンチャントシステムに関する具体的なAPIリクエスト・レスポンスJSON構造（`POST /api/v1/objects/enchant`）および詳細なエラーハンドリング仕様の追加。
+- **解決策**: [アイテムエンチャントシステム仕様](./features/Item-Enchantment-System.md) にて、`POST /api/v1/objects/enchant` のJSON構造（鍛冶屋での付与・強化、エンチャントの巻物使用等）、および各種異常系に対する詳細なエラーコード（`ITEM_NOT_FOUND`, `NO_EMPTY_SLOT`, `INSUFFICIENT_GOLD`, `INSUFFICIENT_MATERIAL`, `SCROLL_NOT_FOUND`, `ITEM_CURSED`, `INVALID_ENCHANT_TYPE`, `DUPLICATE_ENCHANT`）やHTTPステータスのマッピングを策定。
+
 ### [x] モンスター捕獲システムのAPI仕様およびエラーハンドリングの追加
 - **概要**: 確実に実装するのに不足していた、モンスター捕獲システムに関する具体的なAPIリクエスト・レスポンスJSON構造（`POST /api/v1/monsters/capture`）および詳細なエラーハンドリング仕様の追加。
 - **解決策**: [モンスター捕獲システム仕様](./features/Monster-Capture-System.md) にて、`POST /api/v1/monsters/capture` のJSON構造（捕獲成功時・失敗時）、および各種異常系に対する詳細なエラーコード（`MONSTER_NOT_FOUND`, `ITEM_NOT_FOUND`, `INVALID_ITEM_TYPE`, `ALREADY_CAPTURED`, `BOSS_CANNOT_BE_CAPTURED`, `LEVEL_LIMIT_EXCEEDED`, `UNCAPTURABLE_STATUS`）やHTTPステータスのマッピングを策定。

--- a/docs/features/Item-Enchantment-System.md
+++ b/docs/features/Item-Enchantment-System.md
@@ -145,6 +145,85 @@ sequenceDiagram
 - **呪い状態の制約**: 鍛冶屋でのエンチャント付与および強化は、呪われているアイテム（`isCursed = true`）に対しては実行できません。先に「解呪の巻物」等で呪いを解く必要があります。
 - **譲渡・移植制限**: エンチャントされたアイテムを他のアイテムへと直接エンチャント移行（移植）する機能は、ゲームバランス保護のため原則不可能です。
 
-## 8. 今後の拡張
+## 8. APIリクエスト・フローとエラーハンドリング
+
+### 8.1 APIリクエスト仕様
+アイテムにエンチャントを付与・強化するためのエンドポイントおよびリクエスト/レスポンスの構造です。
+
+- **Endpoint**: `POST /api/v1/objects/enchant`
+- **Request Body (JSON - 鍛冶屋での付与例)**:
+```json
+{
+  "userId": "player_uuid_12345",
+  "itemInstanceId": "e30df9bc-2601-4475-bf7e-07df9e19d089",
+  "enchantMethod": "BLACKSMITH",
+  "materialItemId": "fire_stone",
+  "targetEnchantId": "ENCHANT_ATTR_FIRE"
+}
+```
+
+- **Request Body (JSON - エンチャントの巻物使用例)**:
+```json
+{
+  "userId": "player_uuid_12345",
+  "itemInstanceId": "e30df9bc-2601-4475-bf7e-07df9e19d089",
+  "enchantMethod": "SCROLL",
+  "scrollInstanceId": "scroll_instance_uuid_99999"
+}
+```
+
+- **Response Body (JSON - 成功時)**:
+```json
+{
+  "success": true,
+  "result": "SUCCESS",
+  "message": "エンチャント「劫火の」の付与に成功しました！",
+  "item": {
+    "instanceId": "e30df9bc-2601-4475-bf7e-07df9e19d089",
+    "typeId": "silver_sword",
+    "name": "銀の剣",
+    "tier": 2,
+    "metadata": {
+      "isIdentified": true,
+      "atk": 9,
+      "enchantSlots": 2,
+      "enchantments": [
+        {
+          "id": "ENCHANT_ATK",
+          "level": 2,
+          "name": "剛力の",
+          "effects": {
+            "atk": 3
+          }
+        },
+        {
+          "id": "ENCHANT_ATTR_FIRE",
+          "level": 1,
+          "name": "劫火の",
+          "effects": {
+            "attribute": "Fire"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### 8.2 エラーハンドリング (Error Handling)
+処理の過程で異常が検出された場合、システムは適切なエラーコードおよび HTTP ステータスを返却します。
+
+| エラーコード | 発生条件 | レスポンス HTTP ステータス | 戻り値のメッセージ例 |
+| :--- | :--- | :---: | :--- |
+| `ITEM_NOT_FOUND` | 指定された `itemInstanceId` のアイテムが存在しない。 | 404 Not Found | 指定されたアイテムが見つかりません。 |
+| `NO_EMPTY_SLOT` | 対象アイテムのエンチャントスロットが埋まっており、空きスロットがない。 | 400 Bad Request | エンチャントスロットに空きがありません。 |
+| `INSUFFICIENT_GOLD` | 鍛冶屋でのエンチャントに必要なゴールドが不足している。 | 400 Bad Request | 所持ゴールドが不足しています。 |
+| `INSUFFICIENT_MATERIAL` | 鍛冶屋でのエンチャントに必要な素材アイテムが存在しない。 | 400 Bad Request | エンチャントに必要な素材アイテムが不足しています。 |
+| `SCROLL_NOT_FOUND` | 指定された `scrollInstanceId` の巻物がインベントリに存在しない。 | 404 Not Found | 使用するエンチャントの巻物が存在しません。 |
+| `ITEM_CURSED` | 対象アイテムが呪われている（`isCursed = true`）。 | 400 Bad Request | 呪われているアイテムにはエンチャントを付与できません。 |
+| `INVALID_ENCHANT_TYPE` | 対象アイテムのカテゴリに対応していないエンチャントが指定された。 | 400 Bad Request | このアイテムカテゴリには指定されたエンチャントを付与できません。 |
+| `DUPLICATE_ENCHANT` | 対象アイテムに既に同一系統のエンチャントが付与されている。 | 400 Bad Request | 既に同じ種類のエンチャントが付与されています。 |
+
+## 9. 今後の拡張
 - **エンチャント抽出**: 不要になった装備から、1つのエンチャントのみを「魔力スクロール」として抽出する機能。
 - **ソウルリンクエンチャント**: プレイヤーの現在 HP やスタミナに応じて、リアルタイムで効果が変動する特殊エンチャント。


### PR DESCRIPTION
確実に実装するのに不足していた「アイテムエンチャントシステム」のAPI仕様（POST /api/v1/objects/enchant）および詳細なエラーハンドリング仕様を `docs/features/Item-Enchantment-System.md` に追加し、`docs/TODO-Details.md` に記録しました。

---
*PR created automatically by Jules for task [6275506062574576681](https://jules.google.com/task/6275506062574576681) started by @yamanakahirofumi*